### PR TITLE
Address bugs found in most recent bug bash 

### DIFF
--- a/sample_tracking/__tests__/import.test.js
+++ b/sample_tracking/__tests__/import.test.js
@@ -99,34 +99,33 @@ const samples = {
     data: [
         {
             Code: "test1",
-            lat: 1,
-            lon: 1,
+            lat: "1",
+            lon: "1",
             d18O_wood: 24.94,
-            origin: "known"
+            trusted: "trusted"
         },
         {
             Code: "test1",
-            lat: 1,
-            lon: 1,
+            lat: "1",
+            lon: "1",
             d18O_wood: 25.94,
-            origin: "known"
+            trusted: "trusted"
         },
         {
             Code: "test2",
-            lat: 4,
-            lon: 4,
-            origin: "unknown"
+            lat: "4",
+            lon: "4",
+            trusted: "unknown"
         },
         {
             Code: "test2",
-            lat: 4,
-            lon: 4,
-            origin: "unknown"
+            lat: "4",
+            lon: "4",
+            trusted: "unknown"
         }
     ]
 }
 
-// beforeAll(() => {
     const batchSet = jest.fn();
     const batchCommit = jest.fn(() => Promise.resolve('test'));
     jest.mock('firebase/firestore', () => {
@@ -158,13 +157,8 @@ const samples = {
             }),
         }
     })
-// });
-
 
 describe('Import', () => {
-
-    
-
 
     it('uploads data correctly', async () => {
         jest.mock('../app/utils', () => {
@@ -185,7 +179,7 @@ describe('Import', () => {
                     return 'test';
                 }),
                 validateImportedEntry: jest.fn(() => {
-                    return '';
+                    return [];
                 })
             }
         });
@@ -208,6 +202,7 @@ describe('Import', () => {
             completeFunction(samples);
         })
         await waitFor(() => expect(batchSet).toHaveBeenCalledTimes(2));
+        console.log("done calling first round")
         expect(batchCommit).toHaveBeenCalledTimes(1);
         expect(batchSet.mock.calls[0][1].points.length).toBe(2);
         expect(batchSet.mock.calls[0][1].lat).toBe(1);
@@ -228,26 +223,26 @@ describe('Import', () => {
         const badSamples = {
             data: [
                 {
-                    Code: "test1",
+                    Code: "test4",
                     d18O_wood: 24.94,
-                    origin: "known"
+                    trusted: "trusted"
                 },
                 {
-                    Code: "test1",
+                    Code: "test4",
                     d18O_wood: 25.94,
-                    origin: "known"
+                    trusted: "trusted"
                 },
                 {
-                    Code: "test2",
+                    Code: "test5",
                     lat: 4,
                     lon: 4,
-                    origin: "unknown"
+                    trusted: "unknown"
                 },
                 {
-                    Code: "test2",
+                    Code: "test5",
                     lat: 4,
                     lon: 4,
-                    origin: "unknown"
+                    trusted: "unknown"
                 }
             ]
         }
@@ -270,7 +265,7 @@ describe('Import', () => {
                     return 'test';
                 }),
                 validateImportedEntry: jest.fn(() => {
-                    return '';
+                    return [];
                 })
             }
         });

--- a/sample_tracking/app/add-sample/page.tsx
+++ b/sample_tracking/app/add-sample/page.tsx
@@ -43,7 +43,6 @@ export default function AddSample() {
     const [formData, setFormData] = useState({
         visibility: 'private',
         collected_by: 'supplier',
-        trusted: 'unknown',
     });
 
     const router = useRouter();
@@ -54,14 +53,14 @@ export default function AddSample() {
 
     let status = "completed";
     const searchParams = useSearchParams();
-    if (typeof window !== "undefined" && !formData.status) {
+    if (typeof window !== "undefined" && !formData.trusted) {
         const queryString = window.location.search;
         console.log("Querystring: " + queryString);
         const urlParams = new URLSearchParams(queryString);
         status = urlParams.get('status') ? urlParams.get('status') : searchParams.get('status');
         setFormData({
             ...formData,
-            status: status === 'completed' ? 'concluded' : 'in_progress',
+            trusted: status === 'originVerification' ? 'untrusted' : 'trusted',
         });
     }
 

--- a/sample_tracking/app/add-sample/page.tsx
+++ b/sample_tracking/app/add-sample/page.tsx
@@ -41,7 +41,7 @@ export default function AddSample() {
     const [sampleCreationFinished, setSampleCreationFinished] = useState(false);
 
     const [formData, setFormData] = useState({
-        visibility: 'public',
+        visibility: 'private',
         collected_by: 'supplier',
         trusted: 'unknown',
     });
@@ -121,6 +121,7 @@ export default function AddSample() {
             org_name: userData.org_name ? userData.org_name : '',
             created_by_name: userData.name,
             code_lab: sampleId,
+            visibility: 'private',
             d18O_wood: formSampleData.d18O_wood ? formSampleData.d18O_wood.map((value: string) => parseFloat(value)) : [],
             d15N_wood: formSampleData.d15N_wood ? formSampleData.d15N_wood.map((value: string) => parseFloat(value)) : [],
             n_wood: formSampleData.n_wood ? formSampleData.n_wood.map((value: string) => parseFloat(value)) : [],

--- a/sample_tracking/app/edit/page.tsx
+++ b/sample_tracking/app/edit/page.tsx
@@ -117,6 +117,7 @@ export default function Edit() {
         if (!user) return;
         const sampleData = {
             ...updatedFormData,
+            visibility: 'private',
             d18O_wood: updatedFormData.d18O_wood ? updatedFormData.d18O_wood.map((value: string) => parseFloat(value)) : [],
             d15N_wood: updatedFormData.d15N_wood ? updatedFormData.d15N_wood.map((value: string) => parseFloat(value)) : [],
             n_wood: updatedFormData.n_wood ? updatedFormData.n_wood.map((value: string) => parseFloat(value)) : [],

--- a/sample_tracking/app/i18n/locales/en/translations.json
+++ b/sample_tracking/app/i18n/locales/en/translations.json
@@ -97,5 +97,6 @@
   "originVerification": "Origin verification",
   "singleReferenceSample": "Single reference sample",
   "unableToDownlaodCsv": "Unable to download CSV file.",
-  "orgNameExists": "An organization with that name already exists"
+  "orgNameExists": "An organization with that name already exists",
+  "isRequired": "is required"
 }

--- a/sample_tracking/app/i18n/locales/en/translations.json
+++ b/sample_tracking/app/i18n/locales/en/translations.json
@@ -95,5 +95,7 @@
   "municipality": "Municipality",
   "weakPassword": "Password should be at least 6 characters long.",
   "originVerification": "Origin verification",
-  "singleReferenceSample": "Single reference sample"
+  "singleReferenceSample": "Single reference sample",
+  "unableToDownlaodCsv": "Unable to download CSV file.",
+  "orgNameExists": "An organization with that name already exists"
 }

--- a/sample_tracking/app/i18n/locales/pt/translations.json
+++ b/sample_tracking/app/i18n/locales/pt/translations.json
@@ -94,5 +94,6 @@
   "municipality": "Município",
   "weakPassword": "A senha deve ter pelo menos 6 caracteres.",
   "originVerification": "Verificação de origem",
-  "singleReferenceSample": "Amostra de referência única"
+  "singleReferenceSample": "Amostra de referência única",
+  "orgNameExists": "Já existe uma organização com esse nome"
 }

--- a/sample_tracking/app/i18n/locales/pt/translations.json
+++ b/sample_tracking/app/i18n/locales/pt/translations.json
@@ -95,5 +95,6 @@
   "weakPassword": "A senha deve ter pelo menos 6 caracteres.",
   "originVerification": "Verificação de origem",
   "singleReferenceSample": "Amostra de referência única",
-  "orgNameExists": "Já existe uma organização com esse nome"
+  "orgNameExists": "Já existe uma organização com esse nome",
+  "isRequired": "é necessário"
 }

--- a/sample_tracking/app/import-samples.tsx
+++ b/sample_tracking/app/import-samples.tsx
@@ -59,7 +59,8 @@ export default function ImportSamples() {
         originValueRequired: t('originValueRequired'),
         latLonRequired: t('latLonRequired'),
         shouldBeWithinTheRange: t('shouldBeWithinTheRange'),
-        and: t('and')
+        and: t('and'),
+        isRequired: t('isRequired')
     }
 
     function onImportSuccessBar() {
@@ -184,7 +185,7 @@ export default function ImportSamples() {
                 const codeList = {};
                 let foundErrors = false;
                 results.data.forEach((result) => {
-                    const errors = validateImportedEntry(result, errorMessages);
+                    const errors = validateImportedEntry(result as Sample, errorMessages);
                     if (errors.length > 0) {
                         result.errors = errors;
                         foundErrors = true;
@@ -223,7 +224,7 @@ export default function ImportSamples() {
                         site: resultValues[0].site || "",
                         state: resultValues[0].state || "",
                         municipality: resultValues[0].municipality || "",
-                        trusted: originValues[resultValues[0].origin],
+                        trusted: resultValues[0].trusted,
                         species: resultValues[0].species || "",
                         created_by: user.uid,
                         created_on: formattedDateString,

--- a/sample_tracking/app/login/login.tsx
+++ b/sample_tracking/app/login/login.tsx
@@ -2,7 +2,7 @@
 import { getAuth, signInWithEmailAndPassword, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation'
-import { doc, collection, getFirestore, addDoc, getDoc } from "firebase/firestore";
+import { doc, collection, getFirestore, addDoc, getDoc, setDoc } from "firebase/firestore";
 import { TextField, Autocomplete, MenuItem, InputAdornment } from '@mui/material';
 import Image from 'next/image'
 import { useTranslation } from 'react-i18next';
@@ -87,7 +87,8 @@ export default function Login(props: LogInProps) {
                         const date = new Date();
                         const dateString = `${date.getMonth() + 1} ${date.getDate()} ${date.getFullYear()}`;
                         // This is a new user. 
-                        addDoc(collection(db, "new_users"), {
+                        const newUserDocRef = doc(db, "new_users", user.uid);
+                        setDoc(newUserDocRef, {
                             name: user.displayName,
                             email: user.email,
                             date_requested: dateString,

--- a/sample_tracking/app/login/signup.tsx
+++ b/sample_tracking/app/login/signup.tsx
@@ -107,13 +107,18 @@ export default function SignUp(props: SignUpProps) {
         }
         if (formData.password !== formData.confirmPassword) {
             setErrorText({
-                ...errorText,
                 confirmPassword: t('passwordsDontMatch')
-            })
+            } as NewUser)
             return;
         }
 
         const newOrgName = formData.newOrgName ? formData.newOrgName : null;
+        if (newOrgName && Object.keys(availableOrgs).includes(newOrgName)) {
+            setErrorText({
+                newOrgName: t('orgNameExists')
+            } as NewUser)
+            return;
+        }
         const orgName = formData.orgName;
         const name = `${formData.firstName} ${formData.lastName}`;
         const labValue = orgName ? availableOrgs[orgName] : '';
@@ -284,6 +289,7 @@ export default function SignUp(props: SignUpProps) {
                             name="newOrgName"
                             label="New org name"
                             value={formData.newOrgName}
+                            helperText={errorText.newOrgName}
                             onChange={(evt: any) => handleChange(evt)}
                         />
                     </div>

--- a/sample_tracking/app/samples/page.tsx
+++ b/sample_tracking/app/samples/page.tsx
@@ -64,7 +64,7 @@ export default function Samples() {
         const untrustedSamples = await getSamplesFromCollection(userData, 'untrusted_samples');
         const unknownSamples = await getSamplesFromCollection(userData, 'unknown_samples');
         if (trustedSamples.length + untrustedSamples.length + unknownSamples.length < 1) {
-            return;
+            setAllSamples({inProgress: [], completed: []});
         }
 
         let inProgressSamples: any = [];

--- a/sample_tracking/app/select-org/page.tsx
+++ b/sample_tracking/app/select-org/page.tsx
@@ -85,7 +85,9 @@ export default function SelectOrg() {
         updateDoc(newUserDocRef, {
             org: orgId,
             org_name: orgName,
-        });
+        }).catch((error) => {
+            console.log(error)
+        })
 
         router.push('/samples');
     }

--- a/sample_tracking/app/styles.css
+++ b/sample_tracking/app/styles.css
@@ -521,7 +521,7 @@
 
 .input-text-field-wrapper {
     margin-top: 32px;
-    /* margin-bottom: 32px; */
+    margin-bottom: 32px;
 }
 
 .half-width {
@@ -1110,7 +1110,8 @@ svg {
 }
 
 .latlon-entry {
-    margin-right: 2px;
+    margin-right: 5px;
+    width: 95%;
 }
 
 .collected-by-wrapper {

--- a/sample_tracking/app/utils.tsx
+++ b/sample_tracking/app/utils.tsx
@@ -65,13 +65,24 @@ export type ErrorMessages = {
   originValueError: string,
   originValueRequired: string,
   latLonRequired: string,
-  ShouldBeWithinRange: string,
   shouldBeWithinTheRange: string,
-  and: string
+  and: string,
+  isRequired: string
 }
 
 export interface NestedSchemas {
   [key: string]: NestedSchemas;
+}
+
+export const SampleErrorType = {
+  'IS_REQUIRED': 'isRequired',
+  'IS_OUT_OF_RANGE': 'isOutOfRange'
+}
+
+export type SampleError = {
+  errorType: string, // SampleErrorType,
+  fieldWithError: string,
+  errorString: string,
 }
 
 const resultRanges = {
@@ -107,6 +118,14 @@ const resultRanges = {
     'min': 40,
     'max': 60
   },
+  'lat': {
+    'min': -90,
+    'max': 90
+  },
+  'lon': {
+    'min': -180,
+    'max': 180
+  }
 }
 
 export const resultValues = ['d18O_wood', 'd15N_wood', 'n_wood', 'd13C_wood', 'c_wood', 'c_cel', 'd13C_cel']
@@ -208,35 +227,93 @@ export function getDocRefForTrustedValue(trusted: string, db: Firestore, sampleI
 }
 
 
-export function validateImportedEntry(data: {}, errorMessages: ErrorMessages): string {
-  let errors = '';
+export function validateImportedEntry(data: Sample, errorMessages: ErrorMessages): string {
+  let errorString = '';
+  const errors = validateSample(data, [1, 2], errorMessages);
+  errors.forEach((error: SampleError) => {
+    errorString += error.errorString;
+  })
+  return errorString
+}
+
+
+export function validateSample(data: Sample, categories: number[], errorMessages: ErrorMessages): SampleError[] {
+  let errors: SampleError[] = [];
   const headers = Object.keys(data);
-  headers.forEach((header: string) => {
-    if (!Object.keys(resultRanges).includes(header)) return;
+
+  if (categories.includes(2)) {  
+    headers.forEach((header: string) => {
+      if (!Object.keys(resultRanges).includes(header)) return;
       const value = parseFloat(data[header])
       if (value < resultRanges[header].min || value > resultRanges[header].max) {
-        errors += `${header} ${errorMessages.ShouldBeWithinRange} ${resultRanges[header].min} ${errorMessages.and} ${resultRanges[header].max}, `;
+        errors.push({
+          errorType: SampleErrorType.IS_OUT_OF_RANGE,
+          fieldWithError: header,
+          errorString: `${header} ${errorMessages.shouldBeWithinTheRange} ${resultRanges[header].min} ${errorMessages.and} ${resultRanges[header].max}`
+        });
       }
-  })
-  if (!headers.includes('lat') || !headers.includes('lon')) {
-    errors += errorMessages.latLonRequired
+    })
   }
-  if (!headers.includes('origin')) {
-    errors += errorMessages.originValueRequired
-  } else {
-    if (!['known', 'unknown', 'uncertain'].includes(data.origin)) {
-      errors += errorMessages.originValueError
+
+  if (categories.includes(1)) {
+    if (!headers.includes('trusted')) {
+      errors.push({
+        errorType: SampleErrorType.IS_REQUIRED,
+        fieldWithError: 'origin',
+        errorString: `origin ${errorMessages.isRequired}`
+      });
+    } else {
+      if (!['trusted', 'unknown', 'untrusted'].includes(data.trusted)) {
+        errors.push({
+          errorType: SampleErrorType.IS_OUT_OF_RANGE,
+          fieldWithError: 'origin',
+          errorString: errorMessages.originValueError
+        });
+      }
+    }
+    if (headers.includes('trusted') && data.trusted !== 'unknown') {
+      if (!headers.includes('lat')) {
+        errors.push({
+          errorType: SampleErrorType.IS_REQUIRED,
+          fieldWithError: 'lat',
+          errorString:  `lat ${errorMessages.isRequired}`
+        });
+      }
+      if (!headers.includes('lon')) {
+        errors.push({
+          errorType: SampleErrorType.IS_REQUIRED,
+          fieldWithError: 'lon',
+          errorString:  `lon ${errorMessages.isRequired}`
+        });
+      }
+      const lat = data['lat'];
+      const lon = data['lon'];
+      if (lat && (lat < -90 || lat > 90)) {
+        errors.push({
+          errorType: SampleErrorType.IS_OUT_OF_RANGE,
+          fieldWithError: 'lat',
+          errorString: `lat ${errorMessages.shouldBeWithinTheRange} ${resultRanges['lat'].min} ${errorMessages.and} ${resultRanges['lat'].max}`
+        });
+      }
+      if (lon && (lon < -180 || lon > 180)) {
+        errors.push({
+          errorType: SampleErrorType.IS_OUT_OF_RANGE,
+          fieldWithError: 'lon',
+          errorString: `lon ${errorMessages.shouldBeWithinTheRange} ${resultRanges['lon'].min} ${errorMessages.and} ${resultRanges['lon'].max}`
+        });
+      }
     }
   }
+
   return errors;
 }
 
 export function getMaxLength(formSampleData: Sample): number {
   let maxValue = 0;
   resultValues.forEach((resultValue: string) => {
-      if (formSampleData[resultValue]) {
-          if (formSampleData[resultValue].length > maxValue) maxValue = formSampleData[resultValue].length;
-      }
+    if (formSampleData[resultValue]) {
+      if (formSampleData[resultValue].length > maxValue) maxValue = formSampleData[resultValue].length;
+    }
   });
   return maxValue;
 }
@@ -244,14 +321,14 @@ export function getMaxLength(formSampleData: Sample): number {
 export function getPointsArrayFromSampleResults(formSampleData: Sample): Sample[] {
   const maxValue = getMaxLength(formSampleData);
   let pointsArray: Sample[] = [];
-  for (let i = 0; i < maxValue; i ++) {
-      const currPoint = {} as Sample;
-      resultValues.forEach((value: string) => {
-          if (formSampleData[value] && formSampleData[value][i]) {
-              currPoint[value] = formSampleData[value][i];
-          }
-      })
-      pointsArray.push(currPoint);
+  for (let i = 0; i < maxValue; i++) {
+    const currPoint = {} as Sample;
+    resultValues.forEach((value: string) => {
+      if (formSampleData[value] && formSampleData[value][i]) {
+        currPoint[value] = formSampleData[value][i];
+      }
+    })
+    pointsArray.push(currPoint);
   }
   return pointsArray;
 }


### PR DESCRIPTION
Following bugs addressed: 
- Samples being visible to users not part of organization or removed from organizations 
- Users who are not part of organizations being stuck in infinite loading loop in main samples screen
- Block users from creating an org with an already existing org name
- Connect the new sample validation to the import validation so that both are validated using the same requirements and code
- Validate lat/lon exist somewhere in the world
- Pre set origin state (trusted/untrusted) based on if user selects origin verification or single reference sample when manually creating a new sample 
- User who creates account using google can't select the org they want to join

Manual testing: 
1. Attempt to create a organization with the name 'google'
2. Attempt is rejected and user is given feedback that they cannot use that name
3. Create new account and request to join 'google' organization
4. New user does not see any samples but is shown the main samples screen with empty tables
5. Log out of new user account and into Tom Jones account 
6. Attempt to create a sample with lat of 500
7. User is given feedback telling them the range the lat must be in 
8. Click 'Add sample' in samples screen and select 'Origin verification'
9. Origin is pre-set to 'Uncertain'
10. Click 'Add sample in samples screen and select 'Single reference sample'
11. Origin is pre-set to 'Known'
12. Log out and try to sign up with a new google account
13. User is brought to the select org screen
14. User can select the org they want to join and are forwarded to the samples main page

Tests run: `npm run test`
```
Test Suites: 8 passed, 8 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        1.93 s, estimated 2 s
Ran all test suites.
```