### PR TITLE
Make sure d18O_cel is in points array

### DIFF
--- a/sample_tracking/app/add-sample/page.tsx
+++ b/sample_tracking/app/add-sample/page.tsx
@@ -128,6 +128,7 @@ export default function AddSample() {
             c_wood: formSampleData.c_wood ? formSampleData.c_wood.map((value: string) => parseFloat(value)) : [],
             c_cel: formSampleData.c_cel ? formSampleData.c_cel.map((value: string) => parseFloat(value)) : [],
             d13C_cel: formSampleData.d13C_cel ? formSampleData.d13C_cel.map((value: string) => parseFloat(value)) : [],
+            d18O_cel: formSampleData.d18O_cel ? formSampleData.d18O_cel.map((value: string) => parseFloat(value)) : [],
             lat: formSampleData.lat ? parseFloat(formSampleData.lat) : '',
             lon: formSampleData.lon ? parseFloat(formSampleData.lon) : '',
             points: getPointsArrayFromSampleResults(formSampleData)

--- a/sample_tracking/app/utils.tsx
+++ b/sample_tracking/app/utils.tsx
@@ -128,7 +128,7 @@ const resultRanges = {
   }
 }
 
-export const resultValues = ['d18O_wood', 'd15N_wood', 'n_wood', 'd13C_wood', 'c_wood', 'c_cel', 'd13C_cel']
+export const resultValues = ['d18O_wood', 'd15N_wood', 'n_wood', 'd13C_wood', 'c_wood', 'c_cel', 'd13C_cel', 'd18O_cel']
 
 
 export function getRanHex(size: number): string {


### PR DESCRIPTION
A bug was found where the d18O_cel values were not being added to the points array. 

Manually tested by creating a sample with 2 d18O_cel values and confirming that the same values were added to the samples points array in Firestore. 

Tests: `npm run test`
```
Test Suites: 7 passed, 7 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        2.059 s
Ran all test suites related to changed files.
```