### PR TITLE
Show org name instead of org ID in admin user tables

### DIFF
--- a/sample_tracking/app/all-users/page.tsx
+++ b/sample_tracking/app/all-users/page.tsx
@@ -149,7 +149,7 @@ export default function Users() {
                 size: 100,
             },
             {
-                accessorKey: 'org',
+                accessorKey: 'org_name',
                 header: t('organization'),
                 size: 100,
             },

--- a/sample_tracking/app/sign-up-requests/page.tsx
+++ b/sample_tracking/app/sign-up-requests/page.tsx
@@ -229,7 +229,7 @@ export default function SignUpRequests() {
                                 return (
                                     <tr key={i} id={key}>
                                         <td>{prospectiveUsers[key].name as unknown as string}</td>
-                                        <td>{prospectiveUsers[key].org as unknown as string}</td>
+                                        <td>{prospectiveUsers[key].org_name as unknown as string}</td>
                                         <td>{prospectiveUsers[key].email as unknown as string}</td>
                                         <td>{prospectiveUsers[key].date_requested as unknown as string}</td>
                                         <td className="approve-reject-wrapper"><button onClick={handleRejectMemberClick} type="button" className="btn btn-outline-danger reject-button">Decline</button>


### PR DESCRIPTION
Fix [bug](https://github.com/tnc-br/bugbash/issues/67) where a user's organization ID is shown instead of it's name.

Manual testing:
1. Log onto an admin account
2. Go to Sign up requests and all users page. Confirm that organization names are used instead of IDs. 

Tests run: `npm run test`
```
Test Suites: 8 passed, 8 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        1.905 s, estimated 3 s
Ran all test suites.
```