### PR TITLE
Update instructions for importing csv

### DIFF
--- a/sample_tracking/app/i18n/locales/en/translations.json
+++ b/sample_tracking/app/i18n/locales/en/translations.json
@@ -133,7 +133,7 @@
   "nearbyDeforestationAlertsSource": "Deforestation alerts are provided by <1>MapBiomas Alerta<1>",
   "unableToDownlaodCsv": "Unable to download CSV file.",
   "orgNameExists": "An organization with that name already exists",
-  "isRequired": "is required",
+  "isRequired": "column is required",
   "pctSimilarSamplesStatedOrigin": "{{pct}}% of the time similar samples did not come from the stated origin.",
   "d18OCelSampleMean": "δ<1>18</1>O Cel sample mean",
   "d18OCelSampleVariance": "δ<1>18</1>O Cel sample variance",

--- a/sample_tracking/app/i18n/locales/en/translations.json
+++ b/sample_tracking/app/i18n/locales/en/translations.json
@@ -81,7 +81,7 @@
   "download": "Download",
   "successfullyImportedFile" : "Successfully imported file",
   "great": "Great!",
-  "originValueError": "origin value should be one of the following: known, uncertain, or unknown",
+  "originValueError": "origin value should be one of the following: trusted, untrusted, or unknown",
   "originValueRequired": "origin value is required, ",
   "latLonRequired": "lat and lon are required, ",
   "shouldBeWithinTheRange": "should be within the range",

--- a/sample_tracking/app/i18n/locales/pt/translations.json
+++ b/sample_tracking/app/i18n/locales/pt/translations.json
@@ -83,7 +83,7 @@
   "download": "Download",
   "successfullyImportedFile": "Arquivo importado com sucesso",
   "great": "Ótimo!",
-  "originValueError": "O valor de origem deve ser um dos seguintes: conhecido, incerto ou desconhecido",
+  "originValueError": "O valor de origem deve ser um dos seguintes: trusted, untrusted, or unknown",
   "originValueRequired": "o valor de origem é obrigatório, ",
   "latLonRequired": "lat e lon são obrigatórios,",
   "shouldBeWithinTheRange": "deve estar dentro do intervalo",

--- a/sample_tracking/app/i18n/locales/pt/translations.json
+++ b/sample_tracking/app/i18n/locales/pt/translations.json
@@ -135,7 +135,7 @@
   "nearbyDeforestationAlertsSource": "Os alertas de desmatamento são fornecidos por <1>MapBiomas Alerta<1>",
   "unableToDownlaodCsv": "Não foi possível baixar o arquivo CSV.",
   "orgNameExists": "Já existe uma organização com esse nome",
-  "isRequired": "é necessário",
+  "isRequired": "coluna é obrigatória",
   "pctSimilarSamplesStatedOrigin": "{{pct}}% das vezes amostras semelhantes não vieram da origem declarada.",
   "d18OCelSampleMean": "Média da amostra de δ<1>18</1>O Cel",
   "d18OCelSampleVariance": "Variância da amostra de δ<1>18</1>O Cel",

--- a/sample_tracking/app/import-samples.tsx
+++ b/sample_tracking/app/import-samples.tsx
@@ -63,13 +63,6 @@ export default function ImportSamples() {
     };
     const csvExporter = new ExportToCsv(csvOptions);
 
-
-    const originValues = {
-        unknown: 'unknown',
-        known: 'trusted',
-        uncertain: 'untrusted'
-    }
-
     const errorMessages: ErrorMessages = {
         originValueError: t('originValueError'),
         originValueRequired: t('originValueRequired'),
@@ -283,6 +276,7 @@ export default function ImportSamples() {
                         status: completed ? 'concluded' : 'in_progress',
                     };
                     batch.set(docRef, payload);
+                    console.log("New id added: " + sample.code_lab)
                 });
 
                 batch.commit().then(async () => {

--- a/sample_tracking/app/utils.tsx
+++ b/sample_tracking/app/utils.tsx
@@ -287,7 +287,7 @@ export function validateSample(data: Sample, categories: number[], errorMessages
       errors.push({
         errorType: SampleErrorType.IS_REQUIRED,
         fieldWithError: 'origin',
-        errorString: `origin ${errorMessages.isRequired}`
+        errorString: `trusted ${errorMessages.isRequired}`
       });
     } else {
       if (!['trusted', 'unknown', 'untrusted'].includes(data.trusted)) {


### PR DESCRIPTION
The errors returned when trying to import samples were incorrect and led to people making incorrect changes to the csv. This fixes the error by updating the errors returned to the user so the user can make the correct changes to their csv file. 

Tests run: `npm run test`
```
Test Suites: 8 passed, 8 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        2.268 s
Ran all test suites.
```
 