### PR TITLE
Use code as sample ID on sample imports

### DIFF
--- a/sample_tracking/app/i18n/locales/en/translations.json
+++ b/sample_tracking/app/i18n/locales/en/translations.json
@@ -81,7 +81,7 @@
   "download": "Download",
   "successfullyImportedFile" : "Successfully imported file",
   "great": "Great!",
-  "originValueError": "origin value should be one of the following: known, uncertain, or unknown",
+  "originValueError": "trusted value should be one of the following: known, uncertain, or unknown",
   "originValueRequired": "origin value is required, ",
   "latLonRequired": "lat and lon are required, ",
   "shouldBeWithinTheRange": "should be within the range",

--- a/sample_tracking/app/i18n/locales/en/translations.json
+++ b/sample_tracking/app/i18n/locales/en/translations.json
@@ -82,7 +82,7 @@
   "successfullyImportedFile" : "Successfully imported file",
   "great": "Great!",
   "originValueError": "trusted value should be one of the following: known, uncertain, or unknown",
-  "originValueRequired": "origin value is required, ",
+  "originValueRequired": "trusted value is required, ",
   "latLonRequired": "lat and lon are required, ",
   "shouldBeWithinTheRange": "should be within the range",
   "and": "and",

--- a/sample_tracking/app/i18n/locales/pt/translations.json
+++ b/sample_tracking/app/i18n/locales/pt/translations.json
@@ -83,7 +83,7 @@
   "download": "Download",
   "successfullyImportedFile": "Arquivo importado com sucesso",
   "great": "Ótimo!",
-  "originValueError": "O valor de origem deve ser um dos seguintes: conhecido, incerto ou desconhecido",
+  "originValueError": "trusted o valor deve ser um dos seguintes: conhecido, incerto ou desconhecido",
   "originValueRequired": "o valor de origem é obrigatório, ",
   "latLonRequired": "lat e lon são obrigatórios,",
   "shouldBeWithinTheRange": "deve estar dentro do intervalo",

--- a/sample_tracking/app/i18n/locales/pt/translations.json
+++ b/sample_tracking/app/i18n/locales/pt/translations.json
@@ -84,7 +84,7 @@
   "successfullyImportedFile": "Arquivo importado com sucesso",
   "great": "Ótimo!",
   "originValueError": "trusted o valor deve ser um dos seguintes: conhecido, incerto ou desconhecido",
-  "originValueRequired": "o valor de origem é obrigatório, ",
+  "originValueRequired": "trusted é necessário, ",
   "latLonRequired": "lat e lon são obrigatórios,",
   "shouldBeWithinTheRange": "deve estar dentro do intervalo",
   "and": "e",

--- a/sample_tracking/app/import-samples.tsx
+++ b/sample_tracking/app/import-samples.tsx
@@ -234,7 +234,7 @@ export default function ImportSamples() {
                 //RFC 3339 format
                 const formattedDateString = date.toISOString();
                 Object.keys(codeList).forEach((key: string) => {
-                    const sampleId = getRanHex(20);
+                    const sampleId = key;
                     const resultValues = codeList[key];
                     const newSample = {
                         points: codeList[resultValues[0].Code],

--- a/sample_tracking/app/import-samples.tsx
+++ b/sample_tracking/app/import-samples.tsx
@@ -244,6 +244,7 @@ export default function ImportSamples() {
                         org: currentUserData.org,
                         org_name: currentUserData.org_name ? currentUserData.org_name : '',
                         created_by_name: currentUserData.name,
+                        // code_lab value is equal to the code value for the given sample. 
                         code_lab: sampleId,
                         visibility: "private",
                         // Combine result values into single array of floats.

--- a/sample_tracking/app/utils.tsx
+++ b/sample_tracking/app/utils.tsx
@@ -282,6 +282,16 @@ export function validateSample(data: Sample, categories: number[], errorMessages
     })
   }
 
+  if (categories.length > 1) {
+    // Only imported samples are testing more than one category at a time. 
+    if (!headers.includes('code') && !headers.includes('Code')) {
+      errors.push({
+        errorType: SampleErrorType.IS_REQUIRED,
+        fieldWithError: 'code',
+        errorString: `code ${errorMessages.isRequired}`
+      });
+    }
+  }
   if (categories.includes(1)) {
     if (!headers.includes('trusted')) {
       errors.push({


### PR DESCRIPTION
Fix [this](https://github.com/tnc-br/bugbash/issues/77) bug. When samples are imported, we now require a code value for all rows and use that value as the ID for the sample. If a sample already exists in the collection with that ID the old sample is replaced with the new data. 

Manual testing: 
1. Attempt to upload [this](https://docs.google.com/spreadsheets/d/1hm0jaDYBXzSAIXi-WpJeXB_0KO2vIuBmqAflv1jCcNw/edit#gid=409109326) csv file.
2. In the completed table search for 'mad'. Confirm that there are three samples there with the correct data. 
3. Try to upload the same file again. 
4. Confirm that the total number of samples in the database did not change (because the samples were replaced). 

Tests: `npm run test`
```
Test Suites: 8 passed, 8 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        2.083 s
Ran all test suites.
```