### PR TITLE
Fix errors csv not including errors column

### DIFF
--- a/sample_tracking/__tests__/import.test.js
+++ b/sample_tracking/__tests__/import.test.js
@@ -109,27 +109,27 @@ jest.mock('export-to-csv', () => {
 const samples = {
     data: [
         {
-            Code: "test1",
+            code: "test1",
             lat: "1",
             lon: "1",
             d18O_wood: 24.94,
             trusted: "trusted"
         },
         {
-            Code: "test1",
+            code: "test1",
             lat: "1",
             lon: "1",
             d18O_wood: 25.94,
             trusted: "trusted"
         },
         {
-            Code: "test2",
+            code: "test2",
             lat: "4",
             lon: "4",
             trusted: "unknown"
         },
         {
-            Code: "test2",
+            code: "test2",
             lat: "4",
             lon: "4",
             trusted: "unknown"
@@ -236,23 +236,23 @@ describe('Import', () => {
         const badSamples = {
             data: [
                 {
-                    Code: "test4",
+                    code: "test4",
                     d18O_wood: 24.94,
                     trusted: "trusted"
                 },
                 {
-                    Code: "test4",
+                    code: "test4",
                     d18O_wood: 25.94,
                     trusted: "trusted"
                 },
                 {
-                    Code: "test5",
+                    code: "test5",
                     lat: 4,
                     lon: 4,
                     trusted: "unknown"
                 },
                 {
-                    Code: "test5",
+                    code: "test5",
                     lat: 4,
                     lon: 4,
                     trusted: "unknown"

--- a/sample_tracking/app/import-samples.tsx
+++ b/sample_tracking/app/import-samples.tsx
@@ -238,7 +238,7 @@ export default function ImportSamples() {
                     const sampleId = key;
                     const resultValues = codeList[key];
                     const newSample = {
-                        points: codeList[resultValues[0].Code],
+                        points: codeList[resultValues[0].code],
                         lat: parseFloat(resultValues[0].lat),
                         lon: parseFloat(resultValues[0].lon),
                         site: resultValues[0].site || "",
@@ -256,13 +256,13 @@ export default function ImportSamples() {
                         code_lab: sampleId,
                         visibility: "private",
                         // Combine result values into single array of floats.
-                        d18O_wood: codeList[resultValues[0].Code].filter(data => data.d18O_wood).map((data) => parseFloat(data.d18O_wood)),
-                        d15N_wood: codeList[resultValues[0].Code].filter(data => data.d15N_wood).map((data) => parseFloat(data.d15N_wood)),
-                        n_wood: codeList[resultValues[0].Code].filter(data => data.n_wood).map((data) => parseFloat(data.n_wood)),
-                        d13C_wood: codeList[resultValues[0].Code].filter(data => data.d13C_wood).map((data) => parseFloat(data.d13C_wood)),
-                        c_wood: codeList[resultValues[0].Code].filter(data => data.c_wood).map((data) => parseFloat(data.c_wood)),
-                        c_cel: codeList[resultValues[0].Code].filter(data => data.c_cel).map((data) => parseFloat(data.c_cel)),
-                        d13C_cel: codeList[resultValues[0].Code].filter(data => data.d13C_cel).map((data) => parseFloat(data.d13C_cel)),
+                        d18O_wood: codeList[resultValues[0].code].filter(data => data.d18O_wood).map((data) => parseFloat(data.d18O_wood)),
+                        d15N_wood: codeList[resultValues[0].code].filter(data => data.d15N_wood).map((data) => parseFloat(data.d15N_wood)),
+                        n_wood: codeList[resultValues[0].code].filter(data => data.n_wood).map((data) => parseFloat(data.n_wood)),
+                        d13C_wood: codeList[resultValues[0].code].filter(data => data.d13C_wood).map((data) => parseFloat(data.d13C_wood)),
+                        c_wood: codeList[resultValues[0].code].filter(data => data.c_wood).map((data) => parseFloat(data.c_wood)),
+                        c_cel: codeList[resultValues[0].code].filter(data => data.c_cel).map((data) => parseFloat(data.c_cel)),
+                        d13C_cel: codeList[resultValues[0].code].filter(data => data.d13C_cel).map((data) => parseFloat(data.d13C_cel)),
                     }
                     samples.push(newSample);
                 });

--- a/sample_tracking/app/import-samples.tsx
+++ b/sample_tracking/app/import-samples.tsx
@@ -138,8 +138,16 @@ export default function ImportSamples() {
     }
 
     function handleDownloadClick() {
-        if (errorSampleRef.current) {
-            csvExporter.generateCsv(errorSampleRef.current);
+        let errorSamples = errorSampleRef.current
+        if (errorSamples) {
+            // If there is no error data in the first row, the errors column won't be
+            // picked up by the csvExporter and no errors will be exported. We need to 
+            // artifically add an empty errors string to the first row if there isn't 
+            // an error there already. 
+            if (!errorSamples[0].errors) {
+                errorSamples[0].errors = '';
+            }
+            csvExporter.generateCsv(errorSamples);
         } else {
             alert(t('unableToDownlaodCsv'))
         }

--- a/sample_tracking/app/utils.tsx
+++ b/sample_tracking/app/utils.tsx
@@ -284,7 +284,7 @@ export function validateSample(data: Sample, categories: number[], errorMessages
 
   if (categories.length > 1) {
     // Only imported samples are testing more than one category at a time. 
-    if (!headers.includes('code') && !headers.includes('Code')) {
+    if (!headers.includes('code')) {
       errors.push({
         errorType: SampleErrorType.IS_REQUIRED,
         fieldWithError: 'code',


### PR DESCRIPTION
There was a bug in the import service where if there wasn't an error found in the first row but errors found in lower rows, the csvExport library being used would ignore the errors column of the lower rows. This fixes the bug by adding an empty string to the errors column for the first row if there aren't errors found for it. 

Previously we looked for the header to be capital but to keep all header cases consistent I made small changes in the case of the "code" header reference to only look for the lowercase version.  

Tests run: `npm run test`
```
Test Suites: 8 passed, 8 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        2.609 s, estimated 3 s
Ran all test suites.
```

Manually tested by trying to import a csv file which had errors but previously would not have had an errors row in the exported file and confirming that it had an errors row. I also imported a file with errors on every row to make sure the error on the first row is not overwritten by the empty string. 

Manual testing of code case: I tried importing a csv with case capitalized and confirmed the downloaded error file included errors pointing to a missing 'case' column. I tried importing a csv with lowercase case and confirmed it was correctly uploaded. 