### PR TITLE
Add prod/dev org email

### DIFF
--- a/sample_tracking/app/i18n/locales/en/translations.json
+++ b/sample_tracking/app/i18n/locales/en/translations.json
@@ -153,5 +153,6 @@
   "undeterminedLabel": "Undetermined",
   "possibleDescription": "It's possible your sample comes from the following region",
   "notLikelyDescription": "It's not likely your sample comes from the following region",
-  "trustedDescription": "Trusted Sample"
+  "trustedDescription": "Trusted Sample",
+  "orgNameMustBeOneWord": "Organization name must be one word"
 }

--- a/sample_tracking/app/i18n/locales/pt/translations.json
+++ b/sample_tracking/app/i18n/locales/pt/translations.json
@@ -155,5 +155,6 @@
   "undeterminedLabel": "Indeterminado",
   "possibleDescription": "É possível que sua amostra venha da seguinte região",
   "notLikelyDescription": "É improvável que sua amostra venha da seguinte região",
-  "trustedDescription": "Amostra confiável"
+  "trustedDescription": "Amostra confiável",
+  "orgNameMustBeOneWord": "O nome da organização precisa ser uma palavra"
 }

--- a/sample_tracking/app/sign-up-requests/page.tsx
+++ b/sample_tracking/app/sign-up-requests/page.tsx
@@ -7,7 +7,7 @@ import './styles.css';
 import { useRouter } from 'next/navigation'
 import 'bootstrap/dist/css/bootstrap.css';
 import { getFirestore, getDocs, collection, updateDoc, doc, setDoc, addDoc, getDoc, arrayUnion, arrayRemove, deleteField, query, where, deleteDoc } from "firebase/firestore";
-import { showNavBar, showTopBar, getRanHex, initializeAppIfNecessary } from '../utils';
+import { showNavBar, showTopBar, getRanHex, initializeAppIfNecessary, isProd } from '../utils';
 import { getUserData } from '../firebase_utils';
 
 type UserData = {
@@ -111,7 +111,7 @@ export default function SignUpRequests() {
         const dateString = `${date.getMonth() + 1} ${date.getDate()} ${date.getFullYear()}`;
         const orgId = getRanHex(20);
         const newOrgRef = doc(db, "organizations", orgId);
-        const orgEmail = `${orgName}@timberid.org`;
+        const orgEmail = isProd() ? `${orgName}@timberid.org` : `${orgName}-test@timberid.org`;
         setDoc(newOrgRef, {
             org_name: orgName,
             org_email: orgEmail,

--- a/sample_tracking/app/utils.tsx
+++ b/sample_tracking/app/utils.tsx
@@ -393,7 +393,7 @@ function getFirebaseConfig() {
   }
 }
 
-function isProd(): boolean {
+export function isProd(): boolean {
   if (typeof window !== "undefined") {
     const href = window.location.href;
     return href.includes('timberid.org') && !href.includes('test');


### PR DESCRIPTION
Make the org email created on org creation dependent on if it is being created in a dev or prod environment. 

Manually tested by creating an org in the test env and making sure the new '-test' is added to the email created. 

Tests run: `npm run test`
```
Test Suites: 8 passed, 8 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        2.162 s, estimated 3 s
Ran all test suites.
```

