### PR TITLE
test: add regression coverage for sample name input on add-sample

### DIFF
--- a/sample_tracking/__tests__/add-new-sample-form.test.js
+++ b/sample_tracking/__tests__/add-new-sample-form.test.js
@@ -1,0 +1,125 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import AddNewSample from '../src/old_components/Sample/AddNewSample'
+import '@testing-library/jest-dom'
+
+// Mock Firebase before other imports
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(() => ({})),
+  getApp: jest.fn(() => ({})),
+  getApps: jest.fn(() => []),
+}))
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(() => ({})),
+}))
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+  doc: jest.fn(),
+  setDoc: jest.fn(),
+  getDoc: jest.fn(),
+  collection: jest.fn(),
+}))
+
+jest.mock('firebase/analytics', () => ({
+  getAnalytics: jest.fn(() => ({})),
+  isSupported: jest.fn(() => Promise.resolve(false)),
+}))
+
+jest.mock('../src/services/firebase/config', () => ({
+  db: {},
+  auth: {},
+  app: {},
+}))
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    query: {},
+  })),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+  useSearchParams: jest.fn(() => ({ get: jest.fn() })),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (str) => str,
+    i18n: { changeLanguage: () => new Promise(() => {}) },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+jest.mock('../src/hooks/useFirebaseSamples', () => ({
+  useUserData: jest.fn(() => ({
+    data: {
+      role: 'member',
+      org: '12345',
+      user_id: '12345',
+      name: 'Test User',
+      org_name: 'Test Org',
+    },
+    loading: false,
+    error: null,
+  })),
+}))
+
+jest.mock('react-firebase-hooks/auth', () => ({
+  useAuthState: jest.fn(() => [
+    { uid: '12345', email: 'test@example.com' },
+    false,
+    null,
+  ]),
+}))
+
+describe('AddNewSample form (origin verification flow)', () => {
+  const defaultValue = {
+    visibility: 'private',
+    collected_by: 'supplier',
+    status: 'concluded',
+    trusted: 'untrusted', // add sample -> origin verification
+  }
+
+  it('permite digitar no campo sample name', () => {
+    const { container } = render(
+      <AddNewSample
+        defaultValue={defaultValue}
+        onActionButtonClick={jest.fn()}
+        actionButtonTitle="Create sample"
+        isNewSampleForm={true}
+        sampleId="abc123"
+      />,
+    )
+
+    const input = container.querySelector('input[name="sample_name"]')
+    expect(input).not.toBeNull()
+    expect(input).not.toBeDisabled()
+
+    fireEvent.change(input, { target: { value: 'Minha Amostra' } })
+    expect(input).toHaveValue('Minha Amostra')
+  })
+
+  it('permite digitar no sample name pelo fluxo completo da pagina add-sample', () => {
+    // Full page flow as reported in tnc-br/TimberID-Bugs#133:
+    // add sample -> origin verification -> type in "sample name"
+    jest.requireMock('next/router').useRouter.mockReturnValue({
+      push: jest.fn(),
+      query: { status: 'originVerification' },
+    })
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const AddSample = require('../src/pages/add-sample/page').default
+
+    const { container } = render(<AddSample />)
+
+    const input = container.querySelector('input[name="sample_name"]')
+    expect(input).not.toBeNull()
+    expect(input).not.toBeDisabled()
+
+    fireEvent.change(input, { target: { value: 'Amostra Origem' } })
+    expect(input).toHaveValue('Amostra Origem')
+  })
+})


### PR DESCRIPTION
## Summary

While investigating [tnc-br/TimberID-Bugs#133](https://github.com/tnc-br/TimberID-Bugs/issues/133) ("On the screen to type the sample - typing does not work properly"), I verified the reported flow against current `main` and **the bug appears to be fixed** — most likely by the form rewrite merged in October (#107/#108). Typing into the sample name field works, both rendering `AddNewSample` directly with the origin verification defaults (`trusted: 'untrusted'`) and through the full `add-sample` page flow.

This PR contributes that verification as regression coverage. The existing page tests mock `AddNewSample` away, so nothing guarded the real form inputs until now — if a future refactor breaks typing again, these tests will catch it instead of a field worker in production.

## Notes

- `npx jest __tests__/add-new-sample-form.test.js`: 2 tests passing.
- 5 pre-existing test suites currently fail on `main` (they predate the form rewrite). This PR doesn't touch them, but I'd be happy to help bring them back to green in a follow-up if useful.
- Once this is confirmed, TimberID-Bugs#133 can probably be closed — I left a comment there with the findings.

Obs: sou brasileiro e fico feliz em contribuir em português também, se for mais prático para o time. 🇧🇷
